### PR TITLE
change filetree formatting for readability

### DIFF
--- a/hello_dojo/hello_dojo.md
+++ b/hello_dojo/hello_dojo.md
@@ -70,9 +70,9 @@ The AMD loader will automatically load all sub-dependencies for a requested modu
 At this point you've seen an example of loading and using modules. To define and load your own modules, you'll need to ensure that you are loading your HTML file from an HTTP server (localhost is fine, but you do need an HTTP server since there are security subtleties that will prevent many things from working with the "file:///" protocol). For these examples, you don't need any fancy features in your web server other than the ability to serve files. Add a `demo` directory in the directory that contains your `hellodojo.html` file, and in the `demo` directory create a file named `myModule.js`:
 
 ```
+hellodojo.html
 demo/
     myModule.js
-	hellodojo.html
 ```
 
 Now enter the following in `myModule.js`:


### PR DESCRIPTION
The filetree format in the tutorial sample code makes it look like the `hellodojo.html` file should be inside the `demo/` folder:
![screen shot 2015-10-27 at 4 49 39 pm](https://cloud.githubusercontent.com/assets/4666485/10772140/e09a43b8-7cca-11e5-99c6-1bba62351935.png)

this change makes the example code match the written guideline and makes it clear the `hellodojo.html` file should be outside the `demo/` folder:
![screen shot 2015-10-27 at 4 52 55 pm](https://cloud.githubusercontent.com/assets/4666485/10772233/60b0c1bc-7ccb-11e5-8715-9169f7a77aa4.png)

(the formatting hasn't changed otherwise, I just used Mou to render the markdown without styling for the above image)
